### PR TITLE
Add temporal codebook

### DIFF
--- a/models/pct_detector.py
+++ b/models/pct_detector.py
@@ -77,6 +77,7 @@ class PCT(BasePose):
                 joints_3d_visible=None,
                 img_metas=None,
                 return_loss=True,
+                prev_latent=None,
                 **kwargs):
         """Calls either forward_train or forward_test depending on whether
         return_loss=True. Note this setting will change the expected inputs.
@@ -119,18 +120,20 @@ class PCT(BasePose):
             joints = None
 
         if return_loss:
-            return self.forward_train(img, joints, img_metas, **kwargs)
+            return self.forward_train(img, joints, img_metas,
+                                     prev_latent=prev_latent, **kwargs)
         return self.forward_test(
-            img, joints, img_metas, **kwargs)
+            img, joints, img_metas, prev_latent=prev_latent, **kwargs)
 
-    def forward_train(self, img, joints, img_metas, **kwargs):
+    def forward_train(self, img, joints, img_metas, prev_latent=None, **kwargs):
         """Defines the computation performed at every call when training."""
 
         output = None if self.stage_pct == "tokenizer" else self.backbone(img)
         extra_output = self.extra_backbone(img) if self.image_guide else None
 
-        p_logits, p_joints, g_logits, e_latent_loss = \
-            self.keypoint_head(output, extra_output, joints)
+        p_logits, p_joints, g_logits, e_latent_loss, latent_feat = \
+            self.keypoint_head(output, extra_output, joints,
+                               prev_latent=prev_latent)
 
         # if return loss
         losses = dict()
@@ -153,7 +156,7 @@ class PCT(BasePose):
                     p_joints, joints, e_latent_loss)
             losses.update(keypoint_losses)
         
-        return losses
+        return losses, latent_feat
 
     def get_class_accuracy(self, output, target, topk):
         
@@ -166,7 +169,7 @@ class PCT(BasePose):
             correct[:k].reshape(-1).float().sum(0) \
                 * 100. / batch_size for k in topk]
 
-    def forward_test(self, img, joints, img_metas, **kwargs):
+    def forward_test(self, img, joints, img_metas, prev_latent=None, **kwargs):
         """Defines the computation performed at every call when testing."""
         assert img.size(0) == len(img_metas)
 
@@ -181,8 +184,9 @@ class PCT(BasePose):
         extra_output = self.extra_backbone(img) \
             if self.image_guide and self.stage_pct == "tokenizer" else None
         
-        p_joints, encoding_scores = \
-            self.keypoint_head(output, extra_output, joints, train=False)
+        p_joints, encoding_scores, latent_feat = \
+            self.keypoint_head(output, extra_output, joints,
+                               prev_latent=prev_latent, train=False)
         score_pose = joints[:,:,2:] if self.stage_pct == "tokenizer" else \
             encoding_scores.mean(1, keepdim=True).repeat(1,p_joints.shape[1],1)
 
@@ -206,9 +210,10 @@ class PCT(BasePose):
             else:
                 joints_flipped = None
                 
-            p_joints_f, encoding_scores_f = \
-                self.keypoint_head(features_flipped, \
-                    extra_output_flipped, joints_flipped, train=False)
+            p_joints_f, encoding_scores_f, _ = \
+                self.keypoint_head(features_flipped,
+                    extra_output_flipped, joints_flipped,
+                    prev_latent=prev_latent, train=False)
 
             p_joints_f = p_joints_f[:,FLIP_INDEX[self.dataset_name],:]
             p_joints_f[:,:,0] = img.shape[-1] - 1 - p_joints_f[:,:,0]
@@ -263,7 +268,7 @@ class PCT(BasePose):
         results.update(final_preds)
         results['output_heatmap'] = None
 
-        return results
+        return results, latent_feat
 
     def show_result(self):
         # Not implemented

--- a/models/pct_head.py
+++ b/models/pct_head.py
@@ -133,7 +133,7 @@ class PCT_Head(TopdownHeatmapBaseHead):
                 
         return losses
 
-    def forward(self, x, extra_x, joints=None, train=True):
+    def forward(self, x, extra_x, joints=None, prev_latent=None, train=True):
         """Forward function."""
         
         if self.stage_pct == "classifier":
@@ -164,13 +164,14 @@ class PCT_Head(TopdownHeatmapBaseHead):
         else:
             joints_feat = self.extract_joints_feat(extra_x[-1], joints)
 
-        output_joints, cls_label, e_latent_loss = \
-            self.tokenizer(joints, joints_feat, cls_logits_softmax, train=train)
+        output_joints, cls_label, e_latent_loss, latent_feat = \
+            self.tokenizer(joints, joints_feat, cls_logits_softmax,
+                           prev_latent, train=train)
 
         if train:
-            return cls_logits, output_joints, cls_label, e_latent_loss
+            return cls_logits, output_joints, cls_label, e_latent_loss, latent_feat
         else:
-            return output_joints, encoding_scores
+            return output_joints, encoding_scores, latent_feat
 
     def _make_transition_for_head(self, inplanes, outplanes):
         transition_layer = [

--- a/models/pct_tokenizer.py
+++ b/models/pct_tokenizer.py
@@ -14,6 +14,7 @@ from mmpose.models.builder import HEADS
 from timm.models.layers import trunc_normal_
 
 from .modules import MixerLayer
+from .temporal_codebook import TemporalCodebook
     
 
 @HEADS.register_module()
@@ -35,7 +36,8 @@ class PCT_Tokenizer(nn.Module):
                  tokenizer=None,
                  num_joints=17,
                  guide_ratio=0,
-                 guide_channels=0):
+                 guide_channels=0,
+                 temporal_codebook=None):
         super().__init__()
 
         self.stage_pct = stage_pct
@@ -86,9 +88,19 @@ class PCT_Tokenizer(nn.Module):
         self.codebook.data.normal_()
         self.register_buffer('ema_cluster_size', 
             torch.zeros(self.token_class_num))
-        self.register_buffer('ema_w', 
+        self.register_buffer('ema_w',
             torch.empty(self.token_class_num, self.token_dim))
-        self.ema_w.data.normal_()        
+        self.ema_w.data.normal_()
+
+        if temporal_codebook is not None:
+            assert temporal_codebook['token_dim'] == self.token_dim, \
+                'Temporal codebook dim must match token dim.'
+            self.temporal_codebook = TemporalCodebook(
+                self.token_dim,
+                temporal_codebook['token_class_num'],
+                temporal_codebook.get('ema_decay', 0.9))
+        else:
+            self.temporal_codebook = None
         
         self.decoder_token_mlp = nn.Linear(
             self.token_num, self.num_joints)
@@ -105,7 +117,7 @@ class PCT_Tokenizer(nn.Module):
 
         self.loss = build_loss(tokenizer['loss_keypoint'])
 
-    def forward(self, joints, joints_feature, cls_logits, train=True):
+    def forward(self, joints, joints_feature, cls_logits, prev_latent=None, train=True):
         """Forward function. """
 
         if train or self.stage_pct == "tokenizer":
@@ -148,9 +160,19 @@ class PCT_Tokenizer(nn.Module):
             encoding_indices = None
         
         if self.stage_pct == "classifier":
-            part_token_feat = torch.matmul(cls_logits, self.codebook)
+            spatial_feat = torch.matmul(cls_logits, self.codebook)
         else:
-            part_token_feat = torch.matmul(encodings, self.codebook)
+            spatial_feat = torch.matmul(encodings, self.codebook)
+
+        temporal_indices = None
+        t_loss = None
+        if self.temporal_codebook is not None and prev_latent is not None:
+            diff_feat = encode_feat - prev_latent
+            temporal_feat, temporal_indices, t_loss = self.temporal_codebook(
+                diff_feat, train and self.stage_pct == "tokenizer")
+            part_token_feat = spatial_feat + temporal_feat
+        else:
+            part_token_feat = spatial_feat
 
         if train and self.stage_pct == "tokenizer":
             # Updating Codebook using EMA
@@ -175,6 +197,8 @@ class PCT_Tokenizer(nn.Module):
             self.ema_w = self.ema_w * self.decay + (1 - self.decay) * sync_dw
             self.codebook = self.ema_w / self.ema_cluster_size.unsqueeze(1)
             e_latent_loss = F.mse_loss(part_token_feat.detach(), encode_feat)
+            if t_loss is not None:
+                e_latent_loss = e_latent_loss + t_loss
             part_token_feat = encode_feat + (part_token_feat - encode_feat).detach()
         else:
             e_latent_loss = None
@@ -192,7 +216,7 @@ class PCT_Tokenizer(nn.Module):
 
         recoverd_joints = self.recover_embed(decode_feat)
 
-        return recoverd_joints, encoding_indices, e_latent_loss
+        return recoverd_joints, (encoding_indices, temporal_indices), e_latent_loss, encode_feat.detach()
 
     def get_loss(self, output_joints, joints, e_latent_loss):
         """Calculate loss for training tokenizer.

--- a/models/temporal_codebook.py
+++ b/models/temporal_codebook.py
@@ -1,0 +1,50 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.distributed as dist
+
+class TemporalCodebook(nn.Module):
+    """Vector quantization module for temporal residuals."""
+
+    def __init__(self, token_dim, token_class_num, ema_decay=0.9):
+        super().__init__()
+        self.token_dim = token_dim
+        self.token_class_num = token_class_num
+        self.decay = ema_decay
+
+        self.register_buffer('codebook', torch.empty(token_class_num, token_dim))
+        self.codebook.data.normal_()
+        self.register_buffer('ema_cluster_size', torch.zeros(token_class_num))
+        self.register_buffer('ema_w', torch.empty(token_class_num, token_dim))
+        self.ema_w.data.normal_()
+
+    def forward(self, diff_feat, train=True):
+        bs, dim = diff_feat.shape
+        distances = (diff_feat.pow(2).sum(1, keepdim=True)
+                     + self.codebook.pow(2).sum(1)
+                     - 2 * torch.matmul(diff_feat, self.codebook.t()))
+        encoding_indices = torch.argmin(distances, dim=1)
+        encodings = torch.zeros(bs, self.token_class_num, device=diff_feat.device)
+        encodings.scatter_(1, encoding_indices.unsqueeze(1), 1)
+
+        quantized = torch.matmul(encodings, self.codebook)
+
+        if train:
+            dw = torch.matmul(encodings.t(), diff_feat.detach())
+            n_encodings, n_dw = encodings.numel(), dw.numel()
+            enc_shape, dw_shape = encodings.shape, dw.shape
+            combined = torch.cat((encodings.flatten(), dw.flatten()))
+            if dist.is_initialized():
+                dist.all_reduce(combined)
+            sync_enc, sync_dw = torch.split(combined, [n_encodings, n_dw])
+            sync_enc, sync_dw = sync_enc.view(enc_shape), sync_dw.view(dw_shape)
+            self.ema_cluster_size = self.ema_cluster_size * self.decay + (1 - self.decay) * sync_enc.sum(0)
+            n = self.ema_cluster_size.sum()
+            self.ema_cluster_size = (self.ema_cluster_size + 1e-5) / (n + self.token_class_num * 1e-5) * n
+            self.ema_w = self.ema_w * self.decay + (1 - self.decay) * sync_dw
+            self.codebook = self.ema_w / self.ema_cluster_size.unsqueeze(1)
+            commit_loss = F.mse_loss(quantized.detach(), diff_feat)
+            quantized = diff_feat + (quantized - diff_feat).detach()
+        else:
+            commit_loss = None
+        return quantized, encoding_indices, commit_loss


### PR DESCRIPTION
## Summary
- add a temporal codebook module implementing EMA-based VQ quantization
- integrate temporal codebook into `PCT_Tokenizer`
- propagate previous latent features through `PCTHead` and `PCT` detector so difference can be quantized

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687016fe05d883259ec9ea9bb86d00fb